### PR TITLE
Handle Content-Disposition requests and allow to manually download the response

### DIFF
--- a/index.html
+++ b/index.html
@@ -1297,3 +1297,42 @@ than it'll only restore HTML for the first 3 clicks</p>
     .filter [type="checkbox"] { display: none; }
   </style>
 </div>
+
+
+<h3 id="filters" class="mt-p">Downloading content</h3>
+<p>Twinspark usually handles requests as swaps and requires the server response to
+  contain valid HTML. To download the response content instead, use the
+  <code>Content-Disposition: attachment</code> response header
+  or <code>ts-swap-strategy='download'</code>.
+</p>
+
+<div class="card">
+  <div class="card-header">
+    <h5 class="d-inline mr-2">Demo</h5>
+    <button class="btn btn-link btn-sm reset">Reset</button>
+    <button class="btn btn-link btn-sm source">View Source</button>
+  </div>
+
+  <div class="card-body">
+    <p><a href="/download-disposition" ts-req>Download using <code>Content-Disposition: attachment</code></a></p>
+    <p><a href="/download-strategy" ts-req ts-swap-strategy="attachment">Download using <code>swap-strategy='download'</code></a></p>
+    <p><a href="/download-strategy" ts-req ts-swap-strategy="attachment; filename=custom-name.txt">Download using <code>swap-strategy='download'</code> with a name</a></p>
+    <p><a href="/download-disposition" ts-req ts-swap-strategy="attachment; filename=overridden.txt">Download: override server Content-Disposition header with <code>ts-swap-strategy</code></a></p>
+    <p><a href="/download-disposition" ts-req ts-swap-strategy="swap">Swap: override server Content-Disposition header and do a swap instead</a></p>
+  </div>
+
+  <script>
+    XHRMock.get(/\/download-disposition/, function(req, res) {
+      return res.header('Content-Disposition', 'attachment; filename="content.html"')
+                .header('Content-Type', 'text/plain')
+                .status(200)
+                .body('<p>This is content</p>');
+    });
+    XHRMock.get(/\/download-strategy/, function(req, res) {
+      return res.header('Content-Type', 'text/plain')
+                .status(200)
+                .body('<p>This is content</p>');
+    });
+  </script>
+
+</div>

--- a/index.html
+++ b/index.html
@@ -1299,7 +1299,7 @@ than it'll only restore HTML for the first 3 clicks</p>
 </div>
 
 
-<h3 id="filters" class="mt-p">Downloading content</h3>
+<h3 id="download" class="mt-p">Downloading content</h3>
 <p>Twinspark usually handles requests as swaps and requires the server response to
   contain valid HTML. To download the response content instead, use the
   <code>Content-Disposition: attachment</code> response header

--- a/twinspark.js
+++ b/twinspark.js
@@ -889,6 +889,15 @@
     };
   }
 
+  function download(content, mimeType, filename){
+    const a = document.createElement('a') // Create "a" element
+    const blob = new Blob([content], {type: mimeType}) // Create a blob (file-like object)
+    const url = URL.createObjectURL(blob) // Create an object URL from blob
+    a.setAttribute('href', url) // Set "a" element link
+    a.setAttribute('download', filename) // Set download filename
+    a.click() // Start downloading
+  }
+
   function setReqBody(opts, body) {
     if (!body) {
       return opts;
@@ -957,6 +966,29 @@
 
         if (query.xhr.isAborted) {
           return false;
+        }
+
+        var headers = query.xhr.res.headers();
+        var disposition = headers['content-disposition'];
+
+        origins.forEach(el => {
+          var tempdispo = el.getAttribute('ts-swap-strategy');
+          if (tempdispo !== undefined) disposition = tempdispo;
+        });
+
+        if (disposition && disposition.indexOf('attachment') !== -1)
+        {
+          var filename = 'attachment';
+          var mime = headers['content-type'] || 'application/octet-stream';
+
+          var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+          var matches = filenameRegex.exec(disposition);
+          if (matches != null && matches[1]) {
+            filename = matches[1].replace(/['"]/g, '');
+          }
+
+          download(query.xhr.res.body(), mime, filename);
+          return;
         }
 
         // res.url == "" with mock-xhr


### PR DESCRIPTION
We were implementing an endpoint that validates a form and generates a file. Turns out, twinspark could not handle `Content-Disposition` headers and always requires the HTML response.

I've implemented a simple workaround that automatically detects `Content-Disposition` and stops the request handling. Also I added a way to override this behavior or download the response content that does not come with `Content-Disposition`.

We do not work with complicated batched requests, so please take a look if this makes sense?