### PR TITLE
Create CNAME for getting twinspark.js.org domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+twinspark.js.org


### PR DESCRIPTION
Step 3 to get a domain on [js.org](https://js.org) is to create a CNAME file. So that's it. The next step is making a pull request on their repository: [github.com/js-org/js.org/pull/8188](https://github.com/js-org/js.org/pull/8188). You can add comment to this pull request as approval.
After this we should close issue: [github.com/piranha/twinspark-js/issues/23](https://github.com/piranha/twinspark-js/issues/23)