### PR TITLE
Prevent `target` action from writing an element into the `o.input`

### DIFF
--- a/twinspark.js
+++ b/twinspark.js
@@ -52,7 +52,7 @@
     target: function(sel, o) {
       try {
         o.el = findTarget(o.el, sel);
-        return o.el;
+        return undefined; // do not affect o.input
       } catch(e) {
         return false; // stop executing actions pipeline
       }


### PR DESCRIPTION
Sometimes, I need to select a value from a form, switch targets, and retain that value.